### PR TITLE
feat: simplified Dockerfile, tip for installing the make tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,7 @@ FROM node:16-alpine
 # Build step
 # 1. copy package.json and package-lock.json to /app dir
 RUN mkdir /app
-COPY package*.json /app
 # 2. Change working directory to newly created app dir
-WORKDIR /app
-# 3 . Install dependencies
-RUN npm i
-# 4. Copy the source code to /app dir
-COPY . .
-# 5. Run the app
+WORKDIR ./app/
+# 3. Run the app
 CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ docker run --rm -it -v $PWD:/home/node/app opendigitaleducation/node:16-alpine \
      npx degit ccreusat/workshop-react-dev product-feedback
 ```
 
+When using Ubuntu, you will need to install `make` to initialize the workshop.
+
+```bash
+sudo apt install make
+```
+
 Go into the app directory
 
 ```bash


### PR DESCRIPTION
* No need to copy files in the app/ directory.
* Ubuntu does not have `make` installed by default.