### PR TITLE
Clean unnecessary dependancies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-# Declare the base image
-FROM node:16-alpine
-# Build step
-# 1. copy package.json and package-lock.json to /app dir
-RUN mkdir /app
-# 2. Change working directory to newly created app dir
-WORKDIR ./app/
-# 3. Run the app
-CMD ["npm", "run", "dev"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 install:
 	mkdir -p node_modules
-	docker-compose -p workshop run app sh -c "npm rebuild esbuild && npm install"
+	docker-compose -p workshop run --rm app sh -c "npm rebuild esbuild && npm install"
 
 start:
 	docker-compose -p workshop up

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ npx degit ccreusat/workshop-react-dev product-feedback
 - Node not installed :
 
 ```bash
-docker run --rm -it -v $PWD:/home/node/app opendigitaleducation/node:16-alpine \                                                           
-     npx degit ccreusat/workshop-react-dev product-feedback
+docker run --rm -it -v "$PWD":/home/node/app opendigitaleducation/node:16-alpine \
+  npx degit ccreusat/workshop-react-dev product-feedback
 ```
 
 When using Ubuntu, you will need to install `make` to initialize the workshop.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
 version: "3.8"
 services:
   app:
-    build: .
+    image: node:16-alpine
     container_name: workshop-app
-    ports:
-      - "8000:8000"
+    working_dir: /home/node/app
     volumes:
-      - .:/app
+    - ./:/home/node/app
+    ports:
+    - "8000:8000"
+    command: 
+    - npm
+    - run
+    - dev

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 8000,
-    open: true,
+    open: false,
   },
 });


### PR DESCRIPTION
- Dockerfile can be replaced by simply adding some parameters in the docker-compose.yml
It will save local resources and build time.

- Adding the `--rm` option in the Makefile/install step helps keeping containers cleaned. 
Otherwise, the container generated for every `make install` command will never be removed.

- The `open: false` option in vite server conf is required, because `make start` fails on Linux (and Windows i guess) : a running container has no access to its host by default, and thus cannot open a browser on user's desktop.